### PR TITLE
Enable Cross Account Access for Security Hub Collector

### DIFF
--- a/container-definitions.tpl
+++ b/container-definitions.tpl
@@ -10,7 +10,8 @@
       {"name": "OUTPUT", "value": "${output_path}"},
       {"name": "S3_BUCKET_PATH", "value": "${s3_results_bucket}"},
       {"name": "S3_KEY", "value": "${s3_key}"},
-      {"name": "TEAM_MAP", "value": "${team_map}"}
+      {"name": "TEAM_MAP", "value": "${team_map}"},
+      {"name": "ASSUME_ROLE", "value": "${assume_role}"}
     ],
     "logConfiguration": {
       "logDriver": "awslogs",

--- a/main.tf
+++ b/main.tf
@@ -208,14 +208,14 @@ data "aws_iam_policy_document" "task_execution_role_policy_doc" {
 resource "aws_iam_policy" "assume-role-policy" {
   name = var.assume_role
   path = "/"
-  policy = jsonencode({
-    "Version": "2012-10-17",
-    "Statement": {
-      "Effect": "Allow",
-      "Action": "sts:AssumeRole",
-      "Resource": [for account in local.decoded_team_map.teams[0].accounts : "arn:aws:iam::${account}:role/${var.assume_role}"]
-    }
-  })
+  policy = data.aws_iam_policy_document.assume-role-policy-doc.json
+}
+
+data "aws_iam_policy_document" "assume-role-policy-doc" {
+  statement {
+    actions   = ["sts:AssumeRole"]
+    resources = [for account in local.decoded_team_map.teams[0].accounts : "arn:aws:iam::${account}:role/${var.assume_role}"]
+  }
 }
 
 resource "aws_iam_role_policy_attachment" "shc-attachment" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,6 +1,6 @@
 output "task_execution_role_arn" {
   description = "ARN for the IAM role that is executing the scanner"
-  value       = aws_iam_role.task_role.arn
+  value       = aws_iam_role.task_execution_role.arn
 }
 
 output "ecs_cluster_arn" {

--- a/variables.tf
+++ b/variables.tf
@@ -56,6 +56,11 @@ variable "team_map" {
   description = "JSON file containing team to account mappings"
 }
 
+variable "assume_role" {
+  type        = string
+  description = "The common role name to assume in the different accounts for cross account permissions"
+}
+
 variable "schedule_task_expression" {
   type = string
   description = "Cron based schedule task to run on a cadence"


### PR DESCRIPTION
Changes to the runner module:
* Accepts a new variable, assume_role, which is the common role name to assume across the different accounts security hub collector is collecting from
* Conditionally inject the ARNs of the roles to assume in the different accounts into the IAM policy document, granting the runner permissions to assume those roles.
* Fix the task_role_arn in the task definition and the associated output value.