### PR TITLE
CMCSMACD-147: Implement security-hub-collector ECS for MACBIS

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -214,7 +214,7 @@ resource "aws_iam_policy" "assume-role-policy" {
 data "aws_iam_policy_document" "assume-role-policy-doc" {
   statement {
     actions   = ["sts:AssumeRole"]
-    resources = [for account in local.decoded_team_map.teams[0].accounts : "arn:aws:iam::${account}:role/${var.assume_role}"]
+    resources = flatten([for group in local.decoded_team_map.teams : [for account in group.accounts : "arn:aws:iam::${account}:role/${var.assume_role}"]])
   }
 }
 


### PR DESCRIPTION
The only change in the ECS runner is to make the assume role policy document compatible with a list of more than one account to name groupings. This is achieved with the terraform `flatten` function