### PR TITLE
Use variables for ECS CPU and memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ module "security_hub_collector_runner" {
 | output_path | "SecurityHub-Findings.csv" | File to direct output to.|
 | s3_results_bucket | "" | Bucket value to store security hub collector results. If value is a valid bucket path, CSV files will be streamed to it. |
 | s3_key | "--output" | The S3 key (path/filename) to use (defaults to --output, will have timestamp inserted in name) |
-| ecs_cpu | 256 | The hard limit of CPU units (in CPU units) allocated to the ECS task
-| ecs_memory | 1024 | The hard limit of memory (in MiB) allocated to the ECS task
+| ecs_cpu | 256 | The hard limit of CPU units (in CPU units) allocated to the ECS task |
+| ecs_memory | 1024 | The hard limit of memory (in MiB) allocated to the ECS task |
 
 
 ## Outputs

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ module "security_hub_collector_runner" {
   repo_tag             = "latest"
   ecs_vpc_id           = data.aws_vpc.mac_fc_example_east_sandbox.id
   ecs_subnet_ids       = [data.aws_subnet.private_a.id]
+  ecs_cpu              = // optional, defaults to 256
+  ecs_memory           = // optionals, defaults to 1024
   assign_public_ip     = true // optional, defaults to false
   role_path            = // optional, defaults to "/"
   permissions_boundary = // optional, defaults to ""
@@ -52,6 +54,9 @@ module "security_hub_collector_runner" {
 | output_path | "SecurityHub-Findings.csv" | File to direct output to.|
 | s3_results_bucket | "" | Bucket value to store security hub collector results. If value is a valid bucket path, CSV files will be streamed to it. |
 | s3_key | "--output" | The S3 key (path/filename) to use (defaults to --output, will have timestamp inserted in name) |
+| ecs_cpu | 256 | The hard limit of CPU units (in CPU units) allocated to the ECS task
+| ecs_memory | 1024 | The hard limit of memory (in MiB) allocated to the ECS task
+
 
 ## Outputs
 

--- a/container-definitions.tpl
+++ b/container-definitions.tpl
@@ -2,8 +2,8 @@
   {
     "name": "${app_name}-${environment}-${task_name}",
     "image": "${repo_url}:${repo_tag}",
-    "cpu": 128,
-    "memory": 1024,
+    "cpu": ${cpu},
+    "memory": ${memory},
     "essential": true,
     "portMappings": [],
     "environment": [

--- a/main.tf
+++ b/main.tf
@@ -212,8 +212,8 @@ data "aws_iam_policy_document" "task_execution_role_policy_doc" {
 }
 
 resource "aws_iam_policy" "assume-role-policy" {
-  name = var.assume_role
-  path = var.role_path
+  name   = var.assume_role
+  path   = var.role_path
   policy = data.aws_iam_policy_document.assume-role-policy-doc.json
 }
 
@@ -225,7 +225,7 @@ data "aws_iam_policy_document" "assume-role-policy-doc" {
 }
 
 resource "aws_iam_role_policy_attachment" "shc-attachment" {
-  role = aws_iam_role.task_execution_role.name
+  role       = aws_iam_role.task_execution_role.name
   policy_arn = aws_iam_policy.assume-role-policy.arn
 }
 
@@ -274,18 +274,20 @@ resource "aws_ecs_task_definition" "scheduled_task_def" {
 
   container_definitions = templatefile("${path.module}/container-definitions.tpl",
     {
-      app_name = var.app_name,
-      environment = var.environment,
-      task_name = var.task_name,
-      repo_url = var.repo_url,
-      repo_tag = var.repo_tag,
-      output_path = var.output_path,
+      app_name          = var.app_name,
+      environment       = var.environment,
+      task_name         = var.task_name,
+      repo_url          = var.repo_url,
+      repo_tag          = var.repo_tag,
+      output_path       = var.output_path,
       s3_results_bucket = var.s3_results_bucket,
-      s3_key = var.s3_key,
-      team_map = var.team_map,
-      assume_role = var.assume_role,
-      awslogs_group = local.awslogs_group,
-      awslogs_region = data.aws_region.current.name
+      s3_key            = var.s3_key,
+      team_map          = var.team_map,
+      assume_role       = var.assume_role,
+      awslogs_group     = local.awslogs_group,
+      awslogs_region    = data.aws_region.current.name,
+      cpu               = var.ecs_cpu,
+      memory            = var.ecs_memory
     }
   )
 }

--- a/main.tf
+++ b/main.tf
@@ -268,8 +268,8 @@ resource "aws_ecs_task_definition" "scheduled_task_def" {
   task_role_arn = aws_iam_role.task_execution_role.arn
 
   requires_compatibilities = ["FARGATE"]
-  cpu                      = "256"
-  memory                   = "1024"
+  cpu                      = var.ecs_cpu
+  memory                   = var.ecs_memory
   execution_role_arn       = join("", aws_iam_role.task_execution_role.*.arn)
 
   container_definitions = templatefile("${path.module}/container-definitions.tpl",

--- a/variables.tf
+++ b/variables.tf
@@ -14,7 +14,7 @@ variable "task_name" {
 }
 
 variable "repo_arn" {
-  type = string
+  type        = string
   description = "ARN of the ECR repo hosting the scanner container image"
 }
 
@@ -30,14 +30,14 @@ variable "repo_tag" {
 }
 
 variable "ecs_vpc_id" {
-  type = string
+  type        = string
   description = "VPC ID to be used by ECS"
 }
 
 variable "output_path" {
-  type = string
+  type        = string
   description = "File to direct output to. (default: SecurityHub-Findings.csv)"
-  default = ""
+  default     = ""
 }
 
 variable "s3_results_bucket" {
@@ -46,9 +46,9 @@ variable "s3_results_bucket" {
 }
 
 variable "s3_key" {
-  type = string
+  type        = string
   description = "The S3 key (path/filename) to use (defaults to --output, will have timestamp inserted in name)"
-  default = ""
+  default     = ""
 }
 
 variable "team_map" {
@@ -62,9 +62,9 @@ variable "assume_role" {
 }
 
 variable "schedule_task_expression" {
-  type = string
+  type        = string
   description = "Cron based schedule task to run on a cadence"
-  default = "cron(30 9 * * ? *)" // run 9:30 everyday"
+  default     = "cron(30 9 * * ? *)" // run 9:30 everyday"
 }
 
 variable "logs_cloudwatch_group_arn" {
@@ -98,4 +98,16 @@ variable "permissions_boundary" {
   description = "ARN of the policy that is used to set the permissions boundary for the role"
   type        = string
   default     = ""
+}
+
+variable "ecs_cpu" {
+  description = "The hard limit of CPU units (in CPU units) allocated to the ECS task"
+  type        = number
+  default     = 256
+}
+
+variable "ecs_memory" {
+  description = "The hard limit of memory (in MiB) allocated to the ECS task"
+  type        = number
+  default     = 1024
 }


### PR DESCRIPTION
This change is updates the module to use variables for CPU and memory instead of hard-coded values, to accommodate cases when the ECS task is running out of memory.  It sets defaults for these values and documents them in the README. 

Note that there's a bit of whitespace diff noise from running `terraform fmt`

Manual testing:
I set overrides for the defaults in a module that consumes this module (`security-hub-collector` in the `mac-fc-infra` repo) and applied successfully. 