### PR TITLE
Add variable to enable/disable ECS scheduled task

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This repo contains a Terraform module for a scheduled ECS task that periodically
 
 ```hcl
 module "security_hub_collector_runner" {
-  source      = "github.com/CMSgov/security-hub-collector-ecs-runner?ref=8b712aa2da6b4d900e0d0d60aa732fae048a1b69"
+  source      = "github.com/CMSgov/security-hub-collector-ecs-runner"
   app_name    = "security-hub"
   environment = "dev"
 
@@ -20,8 +20,8 @@ module "security_hub_collector_runner" {
   ecs_vpc_id           = data.aws_vpc.mac_fc_example_east_sandbox.id
   ecs_subnet_ids       = [data.aws_subnet.private_a.id]
   ecs_cpu              = // optional, defaults to 256
-  ecs_memory           = // optionals, defaults to 1024
-  assign_public_ip     = true // optional, defaults to false
+  ecs_memory           = // optional, defaults to 1024
+  assign_public_ip     = // optional, defaults to false
   role_path            = // optional, defaults to "/"
   permissions_boundary = // optional, defaults to ""
 
@@ -56,6 +56,7 @@ module "security_hub_collector_runner" {
 | s3_key | "--output" | The S3 key (path/filename) to use (defaults to --output, will have timestamp inserted in name) |
 | ecs_cpu | 256 | The hard limit of CPU units (in CPU units) allocated to the ECS task |
 | ecs_memory | 1024 | The hard limit of memory (in MiB) allocated to the ECS task |
+| scheduled_task_enabled | true | Whether the scheduled ECS task is enabled or not |
 
 
 ## Outputs

--- a/README.md
+++ b/README.md
@@ -1,10 +1,9 @@
 # security-hub-collector-ecs-runner
 
-This repo contains a Terraform module which will deploy a scheduled ECS
-task which periodically collects security hub findings from the specified AWS accounts. To read more about the security-hub-collector CLI tool, go to [this repository](https://github.com/CMSgov/security-hub-collector). The module supports following features:]
+This repo contains a Terraform module for a scheduled ECS task that periodically collects Security Hub findings from the specified AWS accounts. To read more about the security-hub-collector CLI tool, go to [this repository](https://github.com/CMSgov/security-hub-collector). The module supports the following features:
 
-* Run an ECS task which collects results from Security Hub and outputs to a CSV file in a specified S3 bucket
-* Cloudwatch rule to run tasks on a cron based cadence
+* Run an ECS task that collects results from Security Hub and outputs them to a CSV file in a specified S3 bucket
+* Cloudwatch rule to run tasks on a cron-based cadence
 
 ## Usage
 
@@ -27,6 +26,7 @@ module "security_hub_collector_runner" {
   permissions_boundary = // optional, defaults to ""
 
   schedule_task_expression  = "cron(30 9 * * ? *)"
+  scheduled_task_enabled    = // optional, defaults to true
   logs_cloudwatch_group_arn = aws_cloudwatch_log_group.main.arn
   ecs_cluster_arn           = "arn:aws:ecs:us-east-1:037370603820:cluster/aws-scanner-inspec"
 

--- a/main.tf
+++ b/main.tf
@@ -237,7 +237,7 @@ resource "aws_cloudwatch_event_rule" "run_command" {
   name                = "${var.task_name}-${var.environment}"
   description         = "Scheduled task for ${var.task_name} in ${var.environment}"
   schedule_expression = var.schedule_task_expression
-  is_enabled = var.scheduled_task_enabled
+  is_enabled          = var.scheduled_task_enabled
 }
 
 resource "aws_cloudwatch_event_target" "ecs_scheduled_task" {

--- a/main.tf
+++ b/main.tf
@@ -237,6 +237,7 @@ resource "aws_cloudwatch_event_rule" "run_command" {
   name                = "${var.task_name}-${var.environment}"
   description         = "Scheduled task for ${var.task_name} in ${var.environment}"
   schedule_expression = var.schedule_task_expression
+  is_enabled = var.scheduled_task_enabled
 }
 
 resource "aws_cloudwatch_event_target" "ecs_scheduled_task" {

--- a/variables.tf
+++ b/variables.tf
@@ -111,3 +111,8 @@ variable "ecs_memory" {
   type        = number
   default     = 1024
 }
+variable "scheduled_task_enabled" {
+  description = "Whether the scheduled task is enabled or not"
+  type        = bool
+  default     = true
+}

--- a/variables.tf
+++ b/variables.tf
@@ -111,6 +111,7 @@ variable "ecs_memory" {
   type        = number
   default     = 1024
 }
+
 variable "scheduled_task_enabled" {
   description = "Whether the scheduled task is enabled or not"
   type        = bool


### PR DESCRIPTION
When setting up a test environment for the Security Hub Collector, it became clear that it would be helpful to be able to disable the Collector task when not under active testing.  This change adds a variable to do so and updates the README (with a few housekeeping changes as well) 

Testing:

I fetched the updated module, toggled the variable in the `macbis-test` Terraform, and confirmed in the AWS console. 