### PR TITLE
Update for new team map schema

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -284,8 +284,7 @@ resource "aws_ecs_task_definition" "scheduled_task_def" {
       s3_results_bucket = var.s3_results_bucket,
       s3_key            = var.s3_key,
       team_map          = var.team_map,
-      # remove the trailing slash and concatenate the path with the role name to get the full assume_role value
-      assume_role       = "${replace(var.role_path, "/^\\//", "")}${var.assume_role}"
+      assume_role       = "${var.role_path}${var.assume_role}"
       awslogs_group     = local.awslogs_group,
       awslogs_region    = data.aws_region.current.name,
       cpu               = var.ecs_cpu,

--- a/main.tf
+++ b/main.tf
@@ -220,7 +220,7 @@ resource "aws_iam_policy" "assume-role-policy" {
 data "aws_iam_policy_document" "assume-role-policy-doc" {
   statement {
     actions   = ["sts:AssumeRole"]
-    resources = flatten([for group in local.decoded_team_map.teams : [for account in group.accounts : "arn:aws:iam::${account}:role/${var.assume_role}"]])
+    resources = flatten([for group in local.decoded_team_map.teams : [for account in group.accounts : "arn:aws:iam::${account.id}:role${var.role_path}${var.assume_role}"]])
   }
 }
 
@@ -284,7 +284,8 @@ resource "aws_ecs_task_definition" "scheduled_task_def" {
       s3_results_bucket = var.s3_results_bucket,
       s3_key            = var.s3_key,
       team_map          = var.team_map,
-      assume_role       = var.assume_role,
+      # remove the trailing slash and concatenate the path with the role name to get the full assume_role value
+      assume_role       = "${replace(var.role_path, "/^\\//", "")}${var.assume_role}"
       awslogs_group     = local.awslogs_group,
       awslogs_region    = data.aws_region.current.name,
       cpu               = var.ecs_cpu,

--- a/variables.tf
+++ b/variables.tf
@@ -89,7 +89,7 @@ variable "assign_public_ip" {
 }
 
 variable "role_path" {
-  description = "The path in which to create the assume roles and policies. Refer to https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_identifiers.html for more"
+  description = "The path in which to create the assume roles and policies. Refer to https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_identifiers.html for more. A valid path must begin and end with a forward slash (/)."
   type        = string
   default     = "/"
 }


### PR DESCRIPTION
This change is required because we [changed the team map schema in the Collector](https://github.com/Enterprise-CMCS/security-hub-collector/pull/23) and this module makes assumptions about how the team map is structured.  Ideally, this module would not be housed in a separate repo to make changes like this more obvious, but so it goes.

For context:  
This module sets up an ECS scheduled task to run the Collector against a list of accounts that are specified in the team map. The module uses a cross-account role with permissions to gather Security Hub information, which the ECS task assumes in the target accounts.  To grant the ECS task permission to assume the cross-account role in each account, this module takes the account IDs provided in the team map and creates an IAM permissions policy with a `Resource` of the correct ARN for each target account.  Because the shape of the team map schema changed, the accessor for the ID in the loop that creates these ARNs needs to change as well.

A second change was required to append the `role_path` value to the `assume_role` value to create the complete value that is passed through to the Collector application. 

Testing: I referenced this branch when consuming the module in [mac-fc-infra](https://github.com/Enterprise-CMCS/mac-fc-infra) with:
- a team map with the new schema
- a role path specified
 and confirmed that the Collector ran successfully