### PR TITLE
Use full role ARN and support overriding roles on a per account basis

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,6 @@ module "security_hub_collector_runner" {
   s3_results_bucket = aws_s3_bucket.security_hub_collector.bucket
   s3_key            = ""
   team_map          = filebase64("${path.module}/teammap.json") // read more in Required Parameters
-  assume_role       = "security-hub-collector"
 }
 ```
 
@@ -49,7 +48,6 @@ module "security_hub_collector_runner" {
 
 | Name | Default Value | Description |
 |------|---------|---------|
-| assume_role | "" | Role name to assume when collecting across all accounts |
 | logs_cloudwatch_group_arn | "" | CloudWatch log group arn, overrides values of logs_cloudwatch_retention & logs_cloudwatch_group |
 | output_path | "SecurityHub-Findings.csv" | File to direct output to.|
 | s3_results_bucket | "" | Bucket value to store security hub collector results. If value is a valid bucket path, CSV files will be streamed to it. |

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ module "security_hub_collector_runner" {
   permissions_boundary = // optional, defaults to ""
 
   schedule_task_expression  = "cron(30 9 * * ? *)"
-  scheduled_task_enabled    = // optional, defaults to ENABLED
+  scheduled_task_state      = // optional, defaults to ENABLED
   logs_cloudwatch_group_arn = aws_cloudwatch_log_group.main.arn
   ecs_cluster_arn           = "arn:aws:ecs:us-east-1:037370603820:cluster/aws-scanner-inspec"
 
@@ -54,7 +54,7 @@ module "security_hub_collector_runner" {
 | s3_key | "--output" | The S3 key (path/filename) to use (defaults to --output, will have timestamp inserted in name) |
 | ecs_cpu | 256 | The hard limit of CPU units (in CPU units) allocated to the ECS task |
 | ecs_memory | 1024 | The hard limit of memory (in MiB) allocated to the ECS task |
-| scheduled_task_enabled | ENABLED | Whether the scheduled ECS task is enabled or not |
+| scheduled_task_state | ENABLED | Whether the scheduled ECS task is enabled or not |
 
 
 ## Outputs

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ module "security_hub_collector_runner" {
   permissions_boundary = // optional, defaults to ""
 
   schedule_task_expression  = "cron(30 9 * * ? *)"
-  scheduled_task_enabled    = // optional, defaults to true
+  scheduled_task_enabled    = // optional, defaults to ENABLED
   logs_cloudwatch_group_arn = aws_cloudwatch_log_group.main.arn
   ecs_cluster_arn           = "arn:aws:ecs:us-east-1:037370603820:cluster/aws-scanner-inspec"
 
@@ -54,7 +54,7 @@ module "security_hub_collector_runner" {
 | s3_key | "--output" | The S3 key (path/filename) to use (defaults to --output, will have timestamp inserted in name) |
 | ecs_cpu | 256 | The hard limit of CPU units (in CPU units) allocated to the ECS task |
 | ecs_memory | 1024 | The hard limit of memory (in MiB) allocated to the ECS task |
-| scheduled_task_enabled | true | Whether the scheduled ECS task is enabled or not |
+| scheduled_task_enabled | ENABLED | Whether the scheduled ECS task is enabled or not |
 
 
 ## Outputs

--- a/container-definitions.tpl
+++ b/container-definitions.tpl
@@ -10,8 +10,7 @@
       {"name": "OUTPUT", "value": "${output_path}"},
       {"name": "S3_BUCKET_PATH", "value": "${s3_results_bucket}"},
       {"name": "S3_KEY", "value": "${s3_key}"},
-      {"name": "TEAM_MAP", "value": "${team_map}"},
-      {"name": "ASSUME_ROLE", "value": "${assume_role}"}
+      {"name": "TEAM_MAP", "value": "${team_map}"}
     ],
     "logConfiguration": {
       "logDriver": "awslogs",

--- a/main.tf
+++ b/main.tf
@@ -237,7 +237,7 @@ resource "aws_cloudwatch_event_rule" "run_command" {
   name                = "${var.task_name}-${var.environment}"
   description         = "Scheduled task for ${var.task_name} in ${var.environment}"
   schedule_expression = var.schedule_task_expression
-  is_enabled          = var.scheduled_task_enabled
+  state               = var.scheduled_task_state
 }
 
 resource "aws_cloudwatch_event_target" "ecs_scheduled_task" {

--- a/main.tf
+++ b/main.tf
@@ -212,7 +212,7 @@ data "aws_iam_policy_document" "task_execution_role_policy_doc" {
 }
 
 resource "aws_iam_policy" "assume-role-policy" {
-  name   = var.assume_role
+  name   = "security-hub-collector"
   path   = var.role_path
   policy = data.aws_iam_policy_document.assume-role-policy-doc.json
 }
@@ -220,7 +220,7 @@ resource "aws_iam_policy" "assume-role-policy" {
 data "aws_iam_policy_document" "assume-role-policy-doc" {
   statement {
     actions   = ["sts:AssumeRole"]
-    resources = flatten([for group in local.decoded_team_map.teams : [for account in group.accounts : "arn:aws:iam::${account.id}:role${var.role_path}${var.assume_role}"]])
+    resources = flatten([for group in local.decoded_team_map.teams : [for account in group.accounts : "${account.roleArn}"]])
   }
 }
 
@@ -284,7 +284,6 @@ resource "aws_ecs_task_definition" "scheduled_task_def" {
       s3_results_bucket = var.s3_results_bucket,
       s3_key            = var.s3_key,
       team_map          = var.team_map,
-      assume_role       = "${var.role_path}${var.assume_role}"
       awslogs_group     = local.awslogs_group,
       awslogs_region    = data.aws_region.current.name,
       cpu               = var.ecs_cpu,

--- a/variables.tf
+++ b/variables.tf
@@ -56,11 +56,6 @@ variable "team_map" {
   description = "JSON file containing team to account mappings"
 }
 
-variable "assume_role" {
-  type        = string
-  description = "The common role name to assume in the different accounts for cross account permissions"
-}
-
 variable "schedule_task_expression" {
   type        = string
   description = "Cron based schedule task to run on a cadence"

--- a/variables.tf
+++ b/variables.tf
@@ -107,8 +107,8 @@ variable "ecs_memory" {
   default     = 1024
 }
 
-variable "scheduled_task_enabled" {
-  description = "Whether the scheduled task is enabled or not"
-  type        = bool
-  default     = true
+variable "scheduled_task_state" {
+  description = "Set scheduled task is state. Default is ENABLED, setting this to DISABLED will stop the task"
+  type        = string
+  default     = "ENABLED"
 }


### PR DESCRIPTION
[CMCSMACD-2468](https://jiraent.cms.gov/browse/CMCSMACD-2468) When using the collector across many accounts, the role and role path are not always the same across all accounts.

This change removes the default assume role to support this change to the collector and updates a deprecated terraform value.

Tests:
Deployed to container MAC-FC account and verified that the collector was able to get results