### PR TITLE
Support Athena as source of team data

### DIFF
--- a/container-definitions.tpl
+++ b/container-definitions.tpl
@@ -7,10 +7,12 @@
     "essential": true,
     "portMappings": [],
     "environment": [
-      {"name": "OUTPUT", "value": "${output_path}"},
-      {"name": "S3_BUCKET_PATH", "value": "${s3_results_bucket}"},
+      {"name": "S3_BUCKET", "value": "${s3_results_bucket}"},
       {"name": "S3_KEY", "value": "${s3_key}"},
-      {"name": "TEAM_MAP", "value": "${team_map}"}
+      {"name": "BASE64_TEAM_MAP", "value": "${base64_team_map}"},
+      {"name": "ATHENA_TEAMS_TABLE", "value": "${athena_teams_table}"},
+      {"name": "QUERY_OUTPUT_LOCATION", "value": "${query_output_location}"},
+      {"name": "COLLECTOR_ROLE_PATH", "value": "${collector_role_path}"}
     ],
     "logConfiguration": {
       "logDriver": "awslogs",
@@ -24,7 +26,7 @@
     "mountPoints": [],
     "volumesFrom": [],
     "entryPoint": [
-            "./scriptRunner.sh"
+            "/bin/security-hub-collector"
     ]
   }
 ]

--- a/main.tf
+++ b/main.tf
@@ -153,6 +153,8 @@ resource "aws_iam_role_policy_attachment" "read_only_everything" {
 data "aws_iam_policy_document" "assume_role" {
   statement {
     actions = ["sts:AssumeRole"]
+    # If a team map is provided, add a resource entry for each role ARN in the map.
+    # Otherwise, if an Athena configuration is provided, add a single entry for a role ARN constructed from the provided role path
     resources = local.decoded_team_map != null ? (
       flatten([for group in local.decoded_team_map.teams : [for account in group.accounts : account.roleArn]])
     ) : [(var.team_config.athena != null && var.team_config.athena.collector_role_path != null) ? "arn:aws:iam::*:role/${var.team_config.athena.collector_role_path}" : ""]


### PR DESCRIPTION
This change adds the option to use an Athena table (such as the one we use in Cost Analysis) as a data source, instead of a team map file. We'll use the Athena table option since it's kept up to date, while a team map file will likely not be. 

Check out [this draft PR](https://github.com/Enterprise-CMCS/mac-fc-security-hub-collector/pull/29) for the changes to the Collector that are compatible with this change. Once this change is merged I'll update the module reference in the Collector PR to point to it.

Note on backward compatibility: we have one external consumer, MACPro, and they are [pinned to an earlier SHA of this module](https://github.com/Enterprise-CMCS/macpro-securityhub-collector/blob/7a3c68fd3bd6a7084f5b6a18b9c2ad7bccb01a61/main.tf#L99), so we are theoretically free to do whatever we want without breaking their consumption of the module. However, I wanted to continue to support the team map option in case MACPro asks for some new feature, so we didn't have to go back in our commit history and fork off a commit that still used the team map.  There *are* some breaking changes in this PR that MACPro will need to be aware of if they ever want to adopt this version of the module. This module has never been versioned, but I think we should start now with this as the first major version.

I also did some refactoring of the task role and task execution role for ECS, because it turned out that Truss wasn't even using the task role and had just put all the permissions for both roles on the task execution role and used it for both roles 🦤 

Testing: 
I consumed the updated module in https://github.com/Enterprise-CMCS/mac-fc-security-hub-collector and confirmed:
- all the various variable validation rules work as expected
- applied Terraform and saw the Collector run successfully and upload results to S3
  - I did this both with the Athena and the team map options configured