### PR TITLE
Replace Athena teams table with Teams API

### DIFF
--- a/container-definitions.tpl
+++ b/container-definitions.tpl
@@ -10,9 +10,11 @@
       {"name": "S3_BUCKET", "value": "${s3_results_bucket}"},
       {"name": "S3_KEY", "value": "${s3_key}"},
       {"name": "BASE64_TEAM_MAP", "value": "${base64_team_map}"},
-      {"name": "ATHENA_TEAMS_TABLE", "value": "${athena_teams_table}"},
-      {"name": "QUERY_OUTPUT_LOCATION", "value": "${query_output_location}"},
+      {"name": "TEAMS_API_BASE_URL", "value": "${teams_api_base_url}"},
       {"name": "COLLECTOR_ROLE_PATH", "value": "${collector_role_path}"}
+    ],
+    "secrets": [
+      {"name": "TEAMS_API_KEY", "valueFrom": "${teams_api_key_param}"}
     ],
     "logConfiguration": {
       "logDriver": "awslogs",

--- a/main.tf
+++ b/main.tf
@@ -173,7 +173,7 @@ resource "aws_iam_role_policy_attachment" "assume_role" {
 }
 
 resource "aws_iam_policy" "s3" {
-  name   = "assume-role-${var.app_name}-${var.environment}-${var.task_name}"
+  name   = "s3-${var.app_name}-${var.environment}-${var.task_name}"
   path   = var.role_path
   policy = data.aws_iam_policy_document.s3.json
 }

--- a/main.tf
+++ b/main.tf
@@ -154,10 +154,10 @@ data "aws_iam_policy_document" "assume_role" {
   statement {
     actions = ["sts:AssumeRole"]
     # If a team map is provided, add a resource entry for each role ARN in the map.
-    # Otherwise, if an Athena configuration is provided, add a single entry for a role ARN constructed from the provided role path
+    # Otherwise, if a Teams API configuration is provided, add a single entry for a role ARN constructed from the provided role path
     resources = local.decoded_team_map != null ? (
       flatten([for group in local.decoded_team_map.teams : [for account in group.accounts : account.roleArn]])
-    ) : [(var.team_config.athena != null && var.team_config.athena.collector_role_path != null) ? "arn:aws:iam::*:role/${var.team_config.athena.collector_role_path}" : ""]
+    ) : [(var.team_config.teams_api != null && var.team_config.teams_api.collector_role_path != null) ? "arn:aws:iam::*:role/${var.team_config.teams_api.collector_role_path}" : ""]
   }
 }
 
@@ -172,42 +172,13 @@ resource "aws_iam_role_policy_attachment" "assume_role" {
   policy_arn = aws_iam_policy.assume_role.arn
 }
 
-resource "aws_iam_policy" "athena" {
-  count       = var.team_config.athena != null ? 1 : 0
-  name        = "athena-query-policy"
-  path        = var.role_path
-  description = "Policy for Athena query execution"
-  policy      = data.aws_iam_policy_document.athena[0].json
+resource "aws_iam_policy" "s3" {
+  name   = "assume-role-${var.app_name}-${var.environment}-${var.task_name}"
+  path   = var.role_path
+  policy = data.aws_iam_policy_document.s3.json
 }
 
-data "aws_iam_policy_document" "athena" {
-  count = var.team_config.athena != null ? 1 : 0
-
-  statement {
-    sid       = ""
-    effect    = "Allow"
-    resources = ["*"]
-    actions = [
-      "athena:StartQueryExecution",
-      "athena:GetQueryExecution",
-      "athena:GetQueryResults",
-    ]
-  }
-
-  statement {
-    sid    = "AthenaResultsS3Access"
-    effect = "Allow"
-    resources = [
-      "arn:aws:s3:::${trimprefix(var.team_config.athena.query_output_location, "s3://")}",
-      "arn:aws:s3:::${trimprefix(var.team_config.athena.query_output_location, "s3://")}/*"
-    ]
-    actions = [
-      "s3:GetBucketLocation",
-      "s3:PutObject",
-      "s3:GetObject"
-    ]
-  }
-
+data "aws_iam_policy_document" "s3" {
   statement {
     sid    = "CollectorResultsS3Access"
     effect = "Allow"
@@ -222,10 +193,9 @@ data "aws_iam_policy_document" "athena" {
   }
 }
 
-resource "aws_iam_role_policy_attachment" "athena" {
-  count      = var.team_config.athena != null ? 1 : 0
+resource "aws_iam_role_policy_attachment" "task_s3" {
   role       = aws_iam_role.task_role.name
-  policy_arn = aws_iam_policy.athena[0].arn
+  policy_arn = aws_iam_policy.s3.arn
 }
 
 # Task execution role
@@ -337,21 +307,21 @@ resource "aws_ecs_task_definition" "scheduled_task_def" {
 
   container_definitions = templatefile("${path.module}/container-definitions.tpl",
     {
-      app_name              = var.app_name,
-      environment           = var.environment,
-      task_name             = var.task_name,
-      repo_url              = var.repo_url,
-      repo_tag              = var.repo_tag,
-      s3_results_bucket     = var.s3_results_bucket,
-      s3_key                = var.s3_key,
-      base64_team_map       = var.team_config.base64_team_map != null ? var.team_config.base64_team_map : "",
-      athena_teams_table    = var.team_config.athena != null ? var.team_config.athena.teams_table : "",
-      query_output_location = var.team_config.athena != null ? var.team_config.athena.query_output_location : "",
-      collector_role_path   = var.team_config.athena != null ? var.team_config.athena.collector_role_path : "",
-      awslogs_group         = local.awslogs_group,
-      awslogs_region        = data.aws_region.current.name,
-      cpu                   = var.ecs_cpu,
-      memory                = var.ecs_memory
+      app_name            = var.app_name,
+      environment         = var.environment,
+      task_name           = var.task_name,
+      repo_url            = var.repo_url,
+      repo_tag            = var.repo_tag,
+      s3_results_bucket   = var.s3_results_bucket,
+      s3_key              = var.s3_key,
+      base64_team_map     = var.team_config.base64_team_map != null ? var.team_config.base64_team_map : "",
+      teams_api_base_url  = var.team_config.teams_api != null ? var.team_config.teams_api.base_url : "",
+      teams_api_key_param = var.team_config.teams_api != null ? var.team_config.teams_api.api_key_param : "",
+      collector_role_path = var.team_config.teams_api != null ? var.team_config.teams_api.collector_role_path : "",
+      awslogs_group       = local.awslogs_group,
+      awslogs_region      = data.aws_region.current.name,
+      cpu                 = var.ecs_cpu,
+      memory              = var.ecs_memory
     }
   )
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -7,3 +7,8 @@ output "ecs_cluster_arn" {
   description = "ARN for the ECS cluster where this profile will execute"
   value       = var.ecs_cluster_arn
 }
+
+output "task_security_group_id" {
+  description = "Security group of the ECS task"
+  value       = aws_security_group.ecs_sg.id
+}

--- a/variables.tf
+++ b/variables.tf
@@ -46,19 +46,19 @@ variable "s3_key" {
 }
 
 variable "team_config" {
-  description = "Configuration for the source of team mapping for security hub collector. Specify either base64_team_map or athena fields, but not both."
+  description = "Configuration for the source of team mapping for security hub collector. Specify either base64_team_map or teams_api fields, but not both."
   type = object({
     base64_team_map = optional(string)
-    athena = optional(object({
-      teams_table           = string
-      query_output_location = string
-      collector_role_path   = string
+    teams_api = optional(object({
+      base_url            = string
+      api_key_param       = string
+      collector_role_path = string
     }))
   })
 
   validation {
-    condition     = (var.team_config.base64_team_map != null) != (var.team_config.athena != null)
-    error_message = "Exactly one of team_map or athena must be provided"
+    condition     = (var.team_config.base64_team_map != null) != (var.team_config.teams_api != null)
+    error_message = "Exactly one of base64_team_map or teams_api must be provided"
   }
 
   validation {
@@ -67,12 +67,12 @@ variable "team_config" {
   }
 
   validation {
-    condition = var.team_config.athena == null || (
-      try(var.team_config.athena.teams_table, "") != "" &&
-      try(var.team_config.athena.query_output_location, "") != "" &&
-      try(var.team_config.athena.collector_role_path, "") != ""
+    condition = var.team_config.teams_api == null || (
+      try(var.team_config.teams_api.base_url, "") != "" &&
+      try(var.team_config.teams_api.api_key_param, "") != "" &&
+      try(var.team_config.teams_api.collector_role_path, "") != ""
     )
-    error_message = "When athena is provided, all sub-fields (athena.teams_table, athena.query_output_location, athena.collector_role_path) must be non-empty strings"
+    error_message = "When teams_api is provided, all sub-fields (teams_api.base_url, teams_api.api_key_param, teams_api.collector_role_path) must be non-empty strings"
   }
 }
 


### PR DESCRIPTION
https://jiraent.cms.gov/browse/CMCSMACD-3457

Updates the config to support the Teams API instead of the Athena teams table. This requires changes to the task definition (env vars) and IAM role (fewer perms). Also fixes a few mistakes in the README. Preserves support for the team mapping string (`base64_team_map`) and tries to change as little as possible.

Tested:
- `terraform validate`
- `terraform plan` from the workspaces in `mac-fc-security-hub-collector` with an updated SHA; verified expected changes
- There's no dev environment, so I couldn't fully validate the change, but the Terraform output looks right.