### PR TITLE
Add task definition ARN output

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -12,3 +12,8 @@ output "task_security_group_id" {
   description = "Security group of the ECS task"
   value       = aws_security_group.ecs_sg.id
 }
+
+output "task_definition_arn" {
+  description = "ARN of the ECS task definition"
+  value       = aws_ecs_task_definition.scheduled_task_def.arn
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -13,7 +13,7 @@ output "task_security_group_id" {
   value       = aws_security_group.ecs_sg.id
 }
 
-output "task_definition_arn" {
-  description = "ARN of the ECS task definition"
-  value       = aws_ecs_task_definition.scheduled_task_def.arn
+output "task_definition_arn_without_revision" {
+  description = "ARN of the ECS task definition without revision"
+  value       = aws_ecs_task_definition.scheduled_task_def.arn_without_revision
 }


### PR DESCRIPTION
Add an output of task definition ARN without revision. This is needed so we can set up alerting for the task definition created by the instantiation of this module in https://github.com/Enterprise-CMCS/mac-fc-security-hub-collector.

Testing: 
- [used this branch as the module source ref in the Collector repo](https://github.com/Enterprise-CMCS/mac-fc-security-hub-collector/commit/f66f732bf5021f362d31f3efe1707543bd296302) and consumed the output